### PR TITLE
support node v4.x and v5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - '6'
+  - '5'
+  - '4'
 install:
   - npm install
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 environment:
-  nodejs_version: '6'
+  matrix:
+  - nodejs_version: "6"
+  - nodejs_version: "5"
+  - nodejs_version: "4"
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const clean = rut => {
   return (rut || typeof rut === 'string')
   ? rut.toString().replace(/[^0-9kK]+/g, '').toUpperCase()


### PR DESCRIPTION
Para usar `let` en node 4.x y 5.x se necesita modo _estricto_.