### PR TITLE
to es2015

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,28 +16,28 @@ function validate (rut) {
 
   rut = clean(rut)
 
-  let t = parseInt(rut.slice(0, -1), 10)
-  let m = 0
-  let s = 1
+  var t = parseInt(rut.slice(0, -1), 10)
+  var m = 0
+  var s = 1
 
   while (t > 0) {
-    s = (s + t % 10 * (9 - m++ % 6)) % 11
+    s = (s + (t % 10) * (9 - m++ % 6)) % 11
     t = Math.floor(t / 10)
   }
 
-  const v = s > 0 ? `${s - 1}` : 'K'
+  var v = s > 0 ? '' + (s - 1) : 'K'
   return v === rut.slice(-1)
 }
 
 function format (rut) {
   rut = clean(rut)
 
-  let result = `${rut.slice(-4, -1)}-${rut.substr(rut.length - 1)}`
-  for (let i = 4; i < rut.length; i += 3) {
+  var result = rut.slice(-4, -1) + '-' + rut.substr(rut.length - 1)
+  for (var i = 4; i < rut.length; i += 3) {
     result = rut.slice(-3 - i, -i) + '.' + result
   }
 
   return result
 }
 
-module.exports = { validate, clean, format }
+module.exports = { validate: validate, clean: clean, format: format }


### PR DESCRIPTION
En versiones antiguas de `UglifyJs` el código superior a `es2015` arroja error al compilar.