### PR TITLE
bugfix: does not validate ruts that starts with 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,13 @@ function validate (rut) {
   if (typeof rut !== 'string') {
     return false
   }
+
+  // if it starts with 0 we return false
+  // so a rut like 00000000-0 will not pass
+  if (/^0+/.test(rut)) {
+    return false;
+  }
+
   if (!/^0*(\d{1,3}(\.?\d{3})*)-?([\dkK])$/.test(rut)) {
     return false
   }

--- a/test.js
+++ b/test.js
@@ -36,3 +36,10 @@ test('format', t => {
   t.is(format('18*972*631*7'), '18.972.631-7')
   t.is(format('9068826-k'), '9.068.826-K')
 })
+
+test('does not validate rut with 0 on most right digit', t => {
+  t.false(validate('00.000.000-0'))
+  t.false(validate('00000000-0'))
+  t.false(validate('0000000000000000000000-0'))
+})
+


### PR DESCRIPTION
This commit tries to solve this issue https://github.com/jlobos/rut.js/issues/14
I added a regex to validate as false any rut that starts with a 0. Every test still passes and i added one extra to test the bug.